### PR TITLE
#3 - Backup and restore platforms, sync providers only if not exists

### DIFF
--- a/src/main/appw/cli/snapshots/utils/restore/platforms.py
+++ b/src/main/appw/cli/snapshots/utils/restore/platforms.py
@@ -1,0 +1,33 @@
+"""
+Copyright (c) 2023, The Gallli Network
+"""
+from appw import client
+from appw.cli import log
+from appw.cli.snapshots.utils.restore.utils import data_from
+
+
+@data_from("platforms.json")
+def restore_platforms(data=None, env=None):
+    project_id = env["APPWRITE_PROJECT_ID"]
+
+    log.dim("Syncing app platforms")
+
+    existing = client.list_platforms(project_id)
+
+    for platform in data:
+        exists = list(filter(
+            lambda x: x["$id"] == platform["$id"] or x["name"].lower() == platform["name"].lower(),
+            existing
+        ))
+
+        if exists:
+            log.dim(f"[SKIP] Platform '{platform['name']}' exists", indent=4)
+            continue
+
+        log.success(f"[SYNC] {platform['name']}", indent=4)
+        client.create_platform(
+            project_id,
+            name=platform["name"],
+            type=platform["type"],
+            key=platform["key"],
+        )

--- a/src/main/appw/cli/snapshots/utils/restore/providers.py
+++ b/src/main/appw/cli/snapshots/utils/restore/providers.py
@@ -13,7 +13,19 @@ def restore_auth_providers(data=None, env=None):
 
     log.dim("Syncing auth providers")
 
+    project = client.get_project(project_id)
+    existing = list(
+        map(
+            lambda x: x["name"],
+            filter(lambda x: x["enabled"], project.get("providers", []))
+        )
+    )
+
     for provider in data:
+        if provider["name"] in existing:
+            log.dim(f"[SKIP] {provider['name']} exists", indent=4)
+            continue
+
         log.success(f"[SYNC] {provider['name']}", indent=4)
         client.create_or_update_oauth(
             project_id,

--- a/src/main/appw/cli/snapshots/utils/write.py
+++ b/src/main/appw/cli/snapshots/utils/write.py
@@ -8,6 +8,7 @@ def write_snapshots(snapshot):
     _write_keys_snapshots(snapshot.get("project", {}).get("keys", []))
     _write_providers_snapshots(
         snapshot.get("project", {}).get("providers", []))
+    _write_platforms_snapshots(snapshot.get("platforms", []))
     _write_db_snapshots(snapshot.get("databases", []))
     _write_function_snapshots(snapshot.get("functions", []))
     _write_bucket_snapshots(snapshot.get("buckets", []))
@@ -52,6 +53,14 @@ def _write_providers_snapshots(providers):
     with open(f"{file_root}/providers.json", "w+") as f:
         log.info("✅ [Snapshot] Auth Providers")
         json.dump(_providers, f, indent=4)
+
+
+def _write_platforms_snapshots(platforms):
+    file_root = "snapshot-templates"
+
+    with open(f"{file_root}/platforms.json", "w+") as f:
+        log.info("✅ [Snapshot] Platforms")
+        json.dump(platforms, f, indent=4)
 
 
 def _write_db_snapshots(dbs):


### PR DESCRIPTION
This closes issue #3 - It was missed backing up and restoring platforms. This PR also adds support for not re-creating all the providers if they already exist. This helps having different local vs prod. providers and not overwrite them every time a snapshot is restored. 